### PR TITLE
Prepare for release 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.1] nfcore/quantms - [TBD] - Berlin
+## [1.1.1] nfcore/quantms - [TBD] - Berlin-Bern
 
 ### `Added`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#93](https://github.com/nf-core/quantms/pull/93) Fixed bug in docker vs. singularity container logic in some processes.
 
-### `Dependencies`
-
-### `Parameters`
-
-### `Deprecations`
-
 ## [1.1.0] nfcore/quantms - [03/20/2023] - Berlin
 
 - Bugfixes and speed increases in the OpenMS tools due to version update to 2.9.1

--- a/nextflow.config
+++ b/nextflow.config
@@ -376,7 +376,7 @@ manifest {
     description     = """Quantitative Mass Spectrometry nf-core workflow"""
     mainScript      = 'main.nf'
     nextflowVersion = '!>=22.10.1'
-    version         = '1.1.1dev'
+    version         = '1.1.1'
     doi             = '10.5281/zenodo.7754148'
 }
 


### PR DESCRIPTION
This PR

- updates the version number for release
- extends the release name
- removes some contentless sections from the changelog
